### PR TITLE
feat(vehicles): add vehicles domain and user relations

### DIFF
--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -1,8 +1,10 @@
+import { Vehicle } from 'src/modules/vehicles/entities/vehicle.entity';
 import {
   Column,
   CreateDateColumn,
   Entity,
   Index,
+  OneToMany,
   //   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -53,8 +55,9 @@ export class User {
   @Column({ type: 'json', nullable: true })
   currentLocation?: { latitude: number; longitude: number };
 
-  // @ManyToOne(() => Vehicle, (vehicle) => vehicle.id, { nullable: true })
-  // vehicle?: any;
+  @OneToMany(() => Vehicle, (vehicle) => vehicle.driver)
+  vehicles: Vehicle[];
+
 
   @Column({ type: 'enum', enum: UserStatus, default: UserStatus.ACTIVE })
   status: UserStatus;

--- a/src/modules/vehicles/dto/create-vehicle.dto.ts
+++ b/src/modules/vehicles/dto/create-vehicle.dto.ts
@@ -1,0 +1,77 @@
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsInt,
+  Min,
+  IsUrl,
+  IsDateString,
+  Length,
+  IsBoolean,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { VehicleType, VehicleStatus } from '../entities/vehicle.entity';
+
+export class CreateVehicleDto {
+  @IsString()
+  driverId: string;
+
+  @IsString()
+  @Length(1, 50)
+  make: string;
+
+  @IsString()
+  @Length(1, 50)
+  model: string;
+
+  @IsInt()
+  @Min(1886) 
+  year: number;
+
+  @IsString()
+  @Length(1, 15)
+  plateNumber: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 30)
+  color?: string;
+
+  @IsEnum(VehicleType)
+  @IsOptional()
+  vehicleType?: VehicleType;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  capacity?: number;
+
+  @IsOptional()
+  @IsUrl()
+  licensePlateImageUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  registrationCardUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 100)
+  insurancePolicyNumber?: string;
+
+  @IsOptional()
+  @IsDateString()
+  insuranceExpiresAt?: string;
+
+  @IsOptional()
+  @IsDateString()
+  inspectionDate?: string;
+
+  @IsOptional()
+  @IsEnum(VehicleStatus)
+  status?: VehicleStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/modules/vehicles/dto/update-vehicle.dto.ts
+++ b/src/modules/vehicles/dto/update-vehicle.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateVehicleDto } from './create-vehicle.dto';
+
+export class UpdateVehicleDto extends PartialType(CreateVehicleDto) {}

--- a/src/modules/vehicles/entities/vehicle.entity.ts
+++ b/src/modules/vehicles/entities/vehicle.entity.ts
@@ -1,0 +1,91 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Index,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+} from 'typeorm';
+import { User } from 'src/modules/user/entities/user.entity';
+
+export enum VehicleType {
+  CAR        = 'car',
+  MOTORCYCLE = 'motorcycle',
+  VAN        = 'van',
+  SUV        = 'suv',
+  OTHER      = 'other',
+}
+
+export enum VehicleStatus {
+  PENDING_REVIEW = 'pending_review',
+  APPROVED = 'approved',
+  REJECTED       = 'rejected',
+  MAINTENANCE    = 'maintenance',
+  UNAVAILABLE    = 'unavailable',
+}
+
+@Entity({ name: 'vehicles' })
+@Index(['driver'])
+@Index(['plateNumber'])
+@Index(['vehicleType'])
+@Index(['isActive'])
+@Index(['status'])
+export class Vehicle {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, (user) => user.vehicles, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  driver: User;
+
+  @Column({ length: 50 })
+  make: string;
+
+  @Column({ length: 50 })
+  model: string;
+
+  @Column({ type: 'int' })
+  year: number;
+
+  @Column({ name: 'plate_number', unique: true, length: 15 })
+  plateNumber: string;
+
+  @Column({ nullable: true, length: 30 })
+  color?: string;
+
+  @Column({ type: 'enum', enum: VehicleType, default: VehicleType.CAR })
+  vehicleType: VehicleType;
+
+  @Column({ type: 'int', default: 4 })
+  capacity: number;
+
+  @Column({ nullable: true })
+  licensePlateImageUrl?: string;
+
+  @Column({ nullable: true })
+  registrationCardUrl?: string;
+
+  @Column({ nullable: true, length: 100 })
+  insurancePolicyNumber?: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  insuranceExpiresAt?: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  inspectionDate?: Date;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ type: 'enum', enum: VehicleStatus, default: VehicleStatus.PENDING_REVIEW })
+  status: VehicleStatus;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/src/modules/vehicles/interfaces/vehicle.interface.ts
+++ b/src/modules/vehicles/interfaces/vehicle.interface.ts
@@ -1,0 +1,28 @@
+export type VehicleType = 'car' | 'motorcycle' | 'van' | 'suv' | 'other';
+export type VehicleStatus =
+  | 'pending_review'
+  | 'approved'
+  | 'rejected'
+  | 'maintenance'
+  | 'unavailable';
+
+export interface IVehicle {
+  id: string;
+  driverId: string;
+  make: string;
+  model: string;
+  year: number;
+  plateNumber: string;
+  color?: string;
+  vehicleType: VehicleType;
+  capacity: number;
+  licensePlateImageUrl?: string;
+  registrationCardUrl?: string;
+  insurancePolicyNumber?: string;
+  insuranceExpiresAt?: Date;
+  inspectionDate?: Date;
+  isActive: boolean;
+  status: VehicleStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
- Created IVehicle interface for vehicle typing
- Added Vehicle entity with ORM mappings
- Implemented CreateVehicleDto and UpdateVehicleDto
- Modified User entity to add one-to-many relationship: @OneToMany(() => Vehicle, (vehicle) => vehicle.user) vehicles: Vehicle[];
- Created UpdateUserDto
- Added timestamp fields to all entities (createdAt, updatedAt)

This completes the domain foundation for vehicles and connects them to users.