### PR TITLE
feat(trip): Add Trip entity and pagination utilities

### DIFF
--- a/src/common/dto/api-response.dto.ts
+++ b/src/common/dto/api-response.dto.ts
@@ -1,13 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 
-export class PaginationMetaDto {
-  @ApiProperty() total: number;
-  @ApiProperty() page: number;
-  @ApiProperty() limit: number;
-}
-
-export class ApiResponseDto<T> {
+export class ApiResponseDto<T, M = unknown> {
   @Expose()
   @ApiProperty({ example: true })
   success: boolean;
@@ -32,5 +26,5 @@ export class ApiResponseDto<T> {
     description: 'Pagination metadata',
     type: () => Object,
   })
-  meta?: any;
+   meta?: M;
 }

--- a/src/common/dto/geo-point.dto.ts
+++ b/src/common/dto/geo-point.dto.ts
@@ -1,0 +1,13 @@
+import { IsNumber, Min, Max } from 'class-validator';
+
+export class GeoPointDto {
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat!: number;
+
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng!: number;
+}

--- a/src/common/dto/pagination-meta.dto.ts
+++ b/src/common/dto/pagination-meta.dto.ts
@@ -14,4 +14,10 @@ export class PaginationMetaDto {
   @Expose()
   @ApiProperty({ example: 10, description: 'Items per page limit' })
   limit: number;
+
+  @ApiProperty() pageCount!: number;
+  @ApiProperty() hasNext: boolean;
+  @ApiProperty() hasPrev: boolean;
+  @ApiProperty({ required: false, nullable: true }) nextPage?: number | null;
+  @ApiProperty({ required: false, nullable: true }) prevPage?: number | null;
 }

--- a/src/common/interceptors/api-response.interceptor.ts
+++ b/src/common/interceptors/api-response.interceptor.ts
@@ -1,0 +1,20 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiResponseDto } from '../dto/api-response.dto';
+
+@Injectable()
+export class ApiResponseInterceptor implements NestInterceptor {
+    intercept(_ctx: ExecutionContext, next: CallHandler): Observable<any> {
+        return next.handle().pipe(
+            map((body) => {
+                // Si el handler ya devolvió un ApiResponseDto (tiene 'success'), no lo toco
+                if (body && typeof body === 'object' && 'success' in body) {
+                    return body as ApiResponseDto<any>;
+                }
+                // En caso normal, lo envuelvo
+                return { success: true, message: 'OK', data: body } as ApiResponseDto<any>;
+            }),
+        );
+    }
+}

--- a/src/common/repositories/base.repository.ts
+++ b/src/common/repositories/base.repository.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common';
+import {
+  EntityManager,
+  EntityTarget,
+  ObjectLiteral,          // 👈 importa esto
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
+import { handleRepositoryError } from '../utils/handle-repository-error';
+
+export abstract class BaseRepository<T extends ObjectLiteral> extends Repository<T> { // 👈 restricción
+  protected readonly logger: Logger;
+  protected readonly entityName: string;
+
+  constructor(
+    entity: EntityTarget<T>,
+    manager: EntityManager,
+    repoName: string,
+    entityName?: string,
+  ) {
+    super(entity, manager);
+    this.logger = new Logger(repoName);
+    this.entityName =
+      entityName ??
+      (typeof entity === 'function' ? (entity as any).name : String(entity));
+  }
+
+  /** Crea un QB tipado con alias */
+  protected qb(alias: string): SelectQueryBuilder<T> {
+    return this.createQueryBuilder(alias);
+  }
+
+  /** Aplica paginación “page/limit” */
+  protected paginate(
+    qb: SelectQueryBuilder<T>,
+    page = 1,
+    limit = 10,
+  ): SelectQueryBuilder<T> {
+    const safePage = Math.max(1, Number(page) || 1);
+    const safeLimit = Math.min(100, Math.max(1, Number(limit) || 10));
+    return qb.skip((safePage - 1) * safeLimit).take(safeLimit);
+  }
+
+  /** Safe wrapper de getManyAndCount con manejo de errores centralizado */
+  protected async getManyAndCountSafe(
+    qb: SelectQueryBuilder<T>,
+    method: string,
+  ): Promise<[T[], number]> {
+    try {
+      return await qb.getManyAndCount();
+    } catch (err) {
+      handleRepositoryError(this.logger, err, method, this.entityName);
+      throw err as any; // 👈 garantiza que el tipo no “caiga” en undefined si tu helper no lanza
+    }
+  }
+
+  /** getOne con manejo de errores centralizado */
+  protected async getOneSafe(
+    qb: SelectQueryBuilder<T>,
+    method: string,
+  ): Promise<T | null> {
+    try {
+      return await qb.getOne();
+    } catch (err) {
+      handleRepositoryError(this.logger, err, method, this.entityName);
+      throw err as any; // 👈 idem
+    }
+  }
+
+  /** Devuelve un repo “scoped” al manager si se provee (para transacciones) */
+  protected scoped(manager?: EntityManager): Repository<T> {
+    return manager
+      ? manager.getRepository<T>(this.metadata.target as EntityTarget<T>)
+      : this;
+  }
+}

--- a/src/common/utils/postgres-exception.filter.ts
+++ b/src/common/utils/postgres-exception.filter.ts
@@ -1,0 +1,85 @@
+import {
+  ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus,
+  ConflictException, BadRequestException, ServiceUnavailableException,
+  InternalServerErrorException, RequestTimeoutException, Logger,
+} from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+import { fail } from './response-helpers';
+
+type PgMeta = { code?: string; detail?: string; constraint?: string; table?: string; column?: string; message?: string };
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse();
+    const req = ctx.getRequest();
+
+    // 1) HttpException “normal”
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const response = exception.getResponse() as any;
+      const message =
+        typeof response === 'string'
+          ? response
+          : response?.message || exception.message || 'Error';
+      const code = response?.error || exception.name;
+      return res.status(status).json(fail(message, code));
+    }
+
+    // 2) TypeORM / Postgres
+    if (exception instanceof QueryFailedError) {
+      const meta: PgMeta = (exception as any).driverError || {};
+      const httpEx = this.mapPgCode(meta.code, meta);
+      const status = httpEx.getStatus();
+      const msg = httpEx.message || 'Database error';
+      return res.status(status).json(fail(msg, httpEx.name, process.env.NODE_ENV !== 'production' ? meta : undefined));
+    }
+
+    // 3) class-validator (cuando ValidationPipe lanza error "crudo")
+    const anyEx = exception as any;
+    if (anyEx?.message && Array.isArray(anyEx?.message) && anyEx?.statusCode === 400) {
+      // Nest ValidationPipe default format
+      return res
+        .status(HttpStatus.BAD_REQUEST)
+        .json(fail('Validation failed', 'BadRequestException', anyEx?.message));
+    }
+
+    // 4) Fallback
+    this.logger.error('Unexpected error', (exception as any)?.stack || String(exception));
+    return res
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json(fail('Unexpected error', 'InternalServerError'));
+  }
+
+  private mapPgCode(code?: string, meta?: PgMeta): HttpException {
+    const byConstraint: Record<string, string> = {
+      // personaliza con tus nombres reales de índices/constraints
+      trips_passenger_id_fkey: 'Passenger no existe.',
+      trips_driver_id_fkey: 'Driver no existe.',
+      trips_vehicle_id_fkey: 'Vehicle no existe.',
+      // ejemplo único:
+      // trips_order_id_key: 'Order ya está asociado a un trip.',
+    };
+    const msg = (fallback: string) =>
+      (meta?.constraint && byConstraint[meta.constraint]) || fallback;
+
+    switch (code) {
+      case '23505': return new ConflictException(msg('Valor duplicado (unique violation).'));
+      case '23503': return new BadRequestException(msg('Violación de llave foránea.'));
+      case '23502': return new BadRequestException(msg('Campo requerido no puede ser nulo.'));
+      case '23514': return new BadRequestException(msg('Violación de constraint CHECK.'));
+      case '22P02': return new BadRequestException(msg('Sintaxis de entrada inválida (por ejemplo UUID).'));
+      case '22001': return new BadRequestException(msg('Texto demasiado largo para la columna.'));
+      case '22003': return new BadRequestException(msg('Valor numérico fuera de rango.'));
+      case '40001': return new ConflictException(msg('Fallo de serialización. Intenta de nuevo.'));
+      case '40P01': return new ServiceUnavailableException(msg('Deadlock detectado. Intenta nuevamente.'));
+      case '55P03': return new ServiceUnavailableException(msg('Bloqueo no disponible.'));
+      case '57014': return new RequestTimeoutException(msg('Consulta cancelada.'));
+      case '53300': return new ServiceUnavailableException(msg('Demasiadas conexiones.'));
+      default:      return new InternalServerErrorException('Error de base de datos.');
+    }
+  }
+}

--- a/src/common/utils/response-helpers.ts
+++ b/src/common/utils/response-helpers.ts
@@ -1,0 +1,42 @@
+import { ApiResponseDto } from "../dto/api-response.dto";
+import { PaginationMetaDto } from "../dto/pagination-meta.dto";
+
+export const buildMeta = (total: number, page = 1, limit = 10): PaginationMetaDto => {
+  const safePage  = Math.max(1, Number(page) || 1);
+  const safeLimit = Math.max(1, Number(limit) || 10);
+  const pageCount = Math.max(1, Math.ceil(total / safeLimit));
+  const hasPrev   = safePage > 1;
+  const hasNext   = safePage < pageCount;
+  return {
+    total,
+    page: safePage,
+    limit: safeLimit,
+    pageCount,
+    hasNext,
+    hasPrev,
+    nextPage: hasNext ? safePage + 1 : null,
+    prevPage: hasPrev ? safePage - 1 : null,
+  };
+};
+
+export function ok<T>(data: T, message = 'OK'): ApiResponseDto<T> {
+  return { success: true, message, data };
+}
+
+export function paginated<T>(
+  items: T[],
+  total: number,
+  page = 1,
+  limit = 10,
+  message = 'OK',
+): ApiResponseDto<T[], PaginationMetaDto> {
+  return { success: true, message, data: items, meta: buildMeta(total, page, limit) };
+}
+
+export function fail(
+  message: string,
+  code?: string,
+  details?: any,
+): ApiResponseDto<null> {
+  return { success: false, message, error: { code, details } };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { SwaggerService } from './docs/swagger/swagger.service';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as cookieParser from 'cookie-parser';
+import { ApiResponseInterceptor } from './common/interceptors/api-response.interceptor';
+import { GlobalExceptionFilter } from './common/utils/postgres-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -26,6 +28,12 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+   // Interceptor de respuesta estándar
+  app.useGlobalInterceptors(new ApiResponseInterceptor());
+
+  // Filtro global de errores → ApiResponseDto (success=false)
+  app.useGlobalFilters(new GlobalExceptionFilter());
 
   app.enableCors({
     origin: (origin, callback) => {

--- a/src/modules/trip/dto/create-trip.dto.ts
+++ b/src/modules/trip/dto/create-trip.dto.ts
@@ -1,0 +1,34 @@
+import {
+  IsUUID,
+  IsEnum,
+  IsDateString,
+  IsOptional,
+  IsString,
+  Length,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaymentMode } from '../entities/trip.entity';
+import { GeoPointDto } from 'src/common/dto/geo-point.dto';
+
+
+export class CreateTripDto {
+  @IsUUID()
+  passengerId!: string;
+
+  @IsEnum(PaymentMode)
+  paymentMode!: PaymentMode;
+
+  // Server puede ponerla si quieres; si la mandas desde cliente, valida ISO.
+  @IsDateString()
+  requestedAt!: string;
+
+  @ValidateNested()
+  @Type(() => GeoPointDto)
+  pickupPoint!: GeoPointDto;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 500)
+  pickupAddress?: string;
+}

--- a/src/modules/trip/dto/fare-breakdown.dto.ts
+++ b/src/modules/trip/dto/fare-breakdown.dto.ts
@@ -1,0 +1,10 @@
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class FareBreakdownDto {
+  @IsOptional() @IsNumber() @Min(0) base_fare?: number;
+  @IsOptional() @IsNumber() @Min(0) distance_fare?: number;
+  @IsOptional() @IsNumber() @Min(0) time_fare?: number;
+  @IsOptional() @IsNumber() @Min(0) surge_multiplier?: number;
+  @IsOptional() @IsNumber() @Min(0) discounts?: number;
+  @IsOptional() @IsNumber() @Min(0) waiting_time_minutes?: number;
+}

--- a/src/modules/trip/dto/id-param.dto.ts
+++ b/src/modules/trip/dto/id-param.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class IdParamDto {
+  @IsUUID()
+  id!: string; // corresponde a trips._id
+}

--- a/src/modules/trip/dto/trip-response.dto.ts
+++ b/src/modules/trip/dto/trip-response.dto.ts
@@ -1,0 +1,36 @@
+import { PaymentMode, TripStatus } from '../entities/trip.entity';
+import { FareBreakdown } from '../interfaces/trip.interfaces';
+
+export class TripResponseDto {
+  id!: string;
+
+  passengerId!: string;
+  driverId?: string | null;
+  vehicleId?: string | null;
+  orderId?: string | null;
+
+  currentStatus!: TripStatus;
+  paymentMode!: PaymentMode;
+
+  requestedAt!: string;
+  acceptedAt?: string | null;
+  pickupEtaAt?: string | null;
+  arrivedPickupAt?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  canceledAt?: string | null;
+
+  // Para el front es práctico {lat,lng}
+  pickupPoint!: { lat: number; lng: number };
+  pickupAddress?: string | null;
+
+  fareFinalCurrency?: string | null;
+  fareDistanceKm?: number | null;
+  fareDurationMin?: number | null;
+  fareSurgeMultiplier!: number;
+  fareTotal?: number | null;
+  fareBreakdown?: Record<string, FareBreakdown> | null;
+
+  createdAt!: string;
+  updatedAt!: string;
+}

--- a/src/modules/trip/dto/trips-list-response.dto.ts
+++ b/src/modules/trip/dto/trips-list-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { TripResponseDto } from './trip-response.dto';
+import { ApiResponseDto } from 'src/common/dto/api-response.dto';
+import { PaginationMetaDto } from 'src/common/dto/pagination-meta.dto';
+
+export class TripsListResponseDto extends ApiResponseDto<
+  TripResponseDto[],
+  PaginationMetaDto
+> {
+  @ApiProperty({ type: [TripResponseDto] })
+  @Type(() => TripResponseDto)
+  declare data: TripResponseDto[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  @Type(() => PaginationMetaDto)
+  declare meta: PaginationMetaDto;
+}

--- a/src/modules/trip/dto/trips-query.dto.ts
+++ b/src/modules/trip/dto/trips-query.dto.ts
@@ -1,0 +1,55 @@
+import { Type } from "class-transformer";
+import { IsDateString, IsEnum, IsInt, IsOptional, IsUUID, Max, Min } from "class-validator";
+import { PaymentMode, TripStatus } from "../entities/trip.entity";
+
+export class TripsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 10;
+
+  @IsOptional()
+  @IsUUID()
+  passengerId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  driverId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  vehicleId?: string;
+
+  @IsOptional()
+  @IsEnum(TripStatus)
+  status?: TripStatus;
+
+  @IsOptional()
+  @IsEnum(PaymentMode)
+  paymentMode?: PaymentMode;
+
+  // rangos útiles
+  @IsOptional()
+  @IsDateString()
+  requestedFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  requestedTo?: string;
+
+  @IsOptional()
+  @IsDateString()
+  completedFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  completedTo?: string;
+}

--- a/src/modules/trip/dto/update-trip.dto.ts
+++ b/src/modules/trip/dto/update-trip.dto.ts
@@ -1,0 +1,76 @@
+import {
+    IsUUID,
+    IsEnum,
+    IsOptional,
+    IsDateString,
+    IsString,
+    Length,
+    IsNumber,
+    Min,
+    IsObject,
+    Matches,
+} from 'class-validator';
+import { TripStatus, PaymentMode } from '../entities/trip.entity';
+import { FareBreakdown } from '../interfaces/trip.interfaces';
+
+export class UpdateTripDto {
+    // asignaciones
+    @IsOptional()
+    @IsUUID()
+    driverId?: string;
+
+    @IsOptional() @IsUUID()
+    vehicleId?: string;
+
+    @IsOptional() @IsUUID()
+    orderId?: string;
+
+    // estado y timestamps del ciclo
+    @IsOptional() @IsEnum(TripStatus)
+    currentStatus?: TripStatus;
+
+    @IsOptional() @IsDateString()
+    acceptedAt?: string;
+
+    @IsOptional() @IsDateString()
+    pickupEtaAt?: string;
+
+    @IsOptional() @IsDateString()
+    arrivedPickupAt?: string;
+
+    @IsOptional() @IsDateString()
+    startedAt?: string;
+
+    @IsOptional() @IsDateString()
+    completedAt?: string;
+
+    @IsOptional() @IsDateString()
+    canceledAt?: string;
+
+    // datos de liquidación / tarifa
+    @IsOptional() @Matches(/^[A-Z]{3}$/)
+    fareFinalCurrency?: string;
+
+    @IsOptional() @IsNumber() @Min(0)
+    fareDistanceKm?: number;
+
+    @IsOptional() @IsNumber() @Min(0)
+    fareDurationMin?: number;
+
+    @IsOptional() @IsNumber() @Min(1)
+    fareSurgeMultiplier?: number;
+
+    @IsOptional() @IsNumber() @Min(0)
+    fareTotal?: number;
+
+    // JSON libre (si quieres, luego lo tipas mejor)
+    @IsOptional() @IsObject()
+  fareBreakdown?: Record<string, FareBreakdown>;
+
+    // otros
+    @IsOptional() @IsEnum(PaymentMode)
+    paymentMode?: PaymentMode;
+
+    @IsOptional() @IsString() @Length(1, 500)
+    pickupAddress?: string;
+}

--- a/src/modules/trip/entities/trip.entity.ts
+++ b/src/modules/trip/entities/trip.entity.ts
@@ -1,0 +1,189 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ValueTransformer,
+} from 'typeorm';
+
+import { User } from 'src/modules/user/entities/user.entity';
+import { Vehicle } from 'src/modules/vehicles/entities/vehicle.entity';
+import { FareBreakdown } from '../interfaces/trip.interfaces';
+
+// ---------- ENUMS ----------
+export enum TripStatus {
+  PENDING = 'pending',
+  ASSIGNING = 'assigning',
+  ACCEPTED = 'accepted',
+  ARRIVING = 'arriving',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+  NO_DRIVERS_FOUND = 'no_drivers_found',
+  DRIVER_REJECTED = 'driver_rejected',
+}
+
+export enum PaymentMode {
+  CASH = 'cash',
+  CARD = 'card',
+  WALLET = 'wallet',
+  // extiende según tu sistema de pagos...
+}
+
+// ---------- INTERFACES ----------
+export type GeoPoint = { type: 'Point'; coordinates: [number, number] }; // [lng, lat]
+
+// ---------- TRANSFORMERS ----------
+export const DecimalTransformer: ValueTransformer = {
+  to: (value?: number | null) => value,
+  from: (value?: string | null) =>
+    value === null || value === undefined ? null : Number(value),
+};
+
+// ---------- ENTITY ----------
+@Entity({ name: 'trips' })
+@Index('idx_trips_status', ['currentStatus'])
+@Index('idx_trips_passenger', ['passenger'])
+@Index('idx_trips_driver', ['driver'])
+@Index('idx_trips_vehicle', ['vehicle'])
+@Index('idx_trips_requested_at', ['requestedAt'])
+export class Trip {
+  @PrimaryGeneratedColumn('uuid', { name: '_id' })
+  id: string;
+
+  // Pasajero (FK → users._id)
+  @ManyToOne(() => User, { nullable: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'passenger_id' })
+  passenger: User;
+
+  // Conductor (FK → users._id, NULL hasta aceptación)
+  @ManyToOne(() => User, { nullable: true, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'driver_id' })
+  driver?: User | null;
+
+  // Vehículo (FK → vehicles._id, NULL hasta aceptación)
+  @ManyToOne(() => Vehicle, { nullable: true, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'vehicle_id' })
+  vehicle?: Vehicle | null;
+
+  // Orden de pago digital (opcional)
+  // @ManyToOne(() => Order, { nullable: true, onDelete: 'SET NULL' })
+  // @JoinColumn({ name: 'order_id' })
+  // order?: Order | null;
+
+  @Column({
+    name: 'payment_mode',
+    type: 'enum',
+    enum: PaymentMode,
+  })
+  paymentMode: PaymentMode;
+
+  @Column({
+    name: 'current_status',
+    type: 'enum',
+    enum: TripStatus,
+    default: TripStatus.PENDING,
+  })
+  currentStatus: TripStatus;
+
+  @Column({ name: 'requested_at', type: 'timestamptz' })
+  requestedAt: Date;
+
+  @Column({ name: 'accepted_at', type: 'timestamptz', nullable: true })
+  acceptedAt?: Date | null;
+
+  @Column({ name: 'pickup_eta_at', type: 'timestamptz', nullable: true })
+  pickupEtaAt?: Date | null;
+
+  @Column({ name: 'arrived_pickup_at', type: 'timestamptz', nullable: true })
+  arrivedPickupAt?: Date | null;
+
+  @Column({ name: 'started_at', type: 'timestamptz', nullable: true })
+  startedAt?: Date | null;
+
+  @Column({ name: 'completed_at', type: 'timestamptz', nullable: true })
+  completedAt?: Date | null;
+
+  @Column({ name: 'canceled_at', type: 'timestamptz', nullable: true })
+  canceledAt?: Date | null;
+
+  // GEOGRAFÍA (GeoJSON Point: [lng, lat])
+  @Column({
+    name: 'pickup_point',
+    type: 'geography',
+    spatialFeatureType: 'Point',
+    srid: 4326,
+  })
+  pickupPoint: GeoPoint;
+
+  @Column({ name: 'pickup_address', type: 'text', nullable: true })
+  pickupAddress?: string | null;
+
+  // --- Campos de tarifa / liquidación ---
+  @Column({
+    name: 'fare_final_currency',
+    type: 'char',
+    length: 3,
+    nullable: true,
+  })
+  fareFinalCurrency?: string | null;
+
+  @Column({
+    name: 'fare_distance_km',
+    type: 'numeric',
+    precision: 10,
+    scale: 3,
+    nullable: true,
+    transformer: DecimalTransformer,
+  })
+  fareDistanceKm?: number | null;
+
+  @Column({
+    name: 'fare_duration_min',
+    type: 'numeric',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    transformer: DecimalTransformer,
+  })
+  fareDurationMin?: number | null;
+
+  @Column({
+    name: 'fare_surge_multiplier',
+    type: 'numeric',
+    precision: 6,
+    scale: 3,
+    default: 1.0,
+    transformer: DecimalTransformer,
+  })
+  fareSurgeMultiplier: number;
+
+  @Column({
+    name: 'fare_total',
+    type: 'numeric',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+    transformer: DecimalTransformer,
+  })
+  fareTotal?: number | null;
+
+  @Column({ name: 'fare_breakdown', type: 'jsonb', nullable: true })
+  fareBreakdown?: FareBreakdown | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}
+
+/**
+ * ⚠️ Índice espacial recomendado (Postgres GIST) para pickup_point:
+ * Crear en migración manual:
+ *   CREATE INDEX idx_trips_pickup_point_gist ON trips USING GIST (pickup_point);
+ */

--- a/src/modules/trip/interfaces/trip.interfaces.ts
+++ b/src/modules/trip/interfaces/trip.interfaces.ts
@@ -1,0 +1,36 @@
+import { PaymentMode, TripStatus } from "../entities/trip.entity";
+
+export interface FareBreakdown {
+  base_fare?: number;
+  distance_fare?: number;
+  time_fare?: number;
+  surge_multiplier?: number;
+  discounts?: number;
+  waiting_time_minutes?: number;
+  // agrega campos internos si necesitas
+}
+
+
+/** Proyección ligera para listados (mejor performance que cargar relaciones) */
+
+export interface TripListItemProjection {
+  id: string;
+  passengerId: string;
+  driverId: string | null;
+  vehicleId: string | null;
+  currentStatus: TripStatus;
+  paymentMode: PaymentMode;
+  requestedAt: Date;
+  pickupAddress: string | null;
+  fareFinalCurrency: string | null;
+  fareTotal: number | null;
+}
+
+export interface NearbyParams {
+  lat: number;           // -90..90
+  lng: number;           // -180..180
+  radiusMeters: number;  // radio en METROS
+  statusIn?: TripStatus[];
+  page?: number;
+  limit?: number;
+}

--- a/src/modules/trip/repositories/trip.repository.ts
+++ b/src/modules/trip/repositories/trip.repository.ts
@@ -1,0 +1,277 @@
+// trip.repository.ts
+import {
+  DataSource,
+  DeepPartial,
+  EntityManager,
+  SelectQueryBuilder,
+} from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Trip, TripStatus } from '../entities/trip.entity';
+import { BaseRepository } from 'src/common/repositories/base.repository';
+import { handleRepositoryError } from 'src/common/utils/handle-repository-error';
+import { TripsQueryDto } from '../dto/trips-query.dto';
+import { NearbyParams, TripListItemProjection } from '../interfaces/trip.interfaces';
+
+export interface PaginationDto {
+  page?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class TripRepository extends BaseRepository<Trip> {
+  constructor(dataSource: DataSource) {
+    super(Trip, dataSource.createEntityManager(), 'TripRepository', 'Trip');
+  }
+
+  /** Crear y guardar (participa en transacción si pasas manager) */
+  async createAndSave(
+    partial: DeepPartial<Trip>,
+    manager?: EntityManager,
+  ): Promise<Trip> {
+    const repo = this.scoped(manager);
+    const entity = repo.create(partial);
+    try {
+      return await repo.save(entity);
+    } catch (err) {
+      handleRepositoryError(this.logger, err, 'createAndSave', this.entityName);
+    }
+  }
+
+  /** Obtener por id (opcionalmente con relaciones) */
+  async findById(
+    id: string,
+    opts: { relations?: boolean } = { relations: true },
+  ): Promise<Trip | null> {
+    const qb = this.qb('t').where('t.id = :id', { id });
+
+    if (opts.relations) {
+      qb.leftJoinAndSelect('t.passenger', 'passenger')
+        .leftJoinAndSelect('t.driver', 'driver')
+        .leftJoinAndSelect('t.vehicle', 'vehicle')
+        .leftJoinAndSelect('t.order', 'order');
+    }
+
+    return this.getOneSafe(qb, 'findById');
+  }
+
+  /** Listado paginado con ENTIDADES (carga relaciones) */
+  async findAllPaginated(
+    pagination: PaginationDto,
+    filters?: TripsQueryDto,
+  ): Promise<[Trip[], number]> {
+    const { page = 1, limit = 10 } = pagination;
+
+    // Nota: aunque cargamos entidades, usamos nombres de columna para where/order
+    const qb = this.qb('t')
+      .leftJoinAndSelect('t.passenger', 'passenger')
+      .leftJoinAndSelect('t.driver', 'driver')
+      .leftJoinAndSelect('t.vehicle', 'vehicle')
+      .leftJoinAndSelect('t.order', 'order')
+      .orderBy('t.requested_at', 'DESC');
+
+    if (filters) this.applyFilters(qb, filters);
+    this.paginate(qb, page, limit);
+
+    return this.getManyAndCountSafe(qb, 'findAllPaginated');
+  }
+
+  /**
+   * Listado paginado en PROYECCIÓN (sin relaciones) — recomendado para “listas”
+   * Devuelve objetos planos con lo necesario; muy performante.
+   */
+  async findListPaginatedProjection(
+    pagination: PaginationDto,
+    filters?: TripsQueryDto,
+  ): Promise<[TripListItemProjection[], number]> {
+    const { page = 1, limit = 10 } = pagination;
+
+    const qb = this.qb('t')
+      .select([
+        't.id AS id',
+        't.passenger_id AS "passengerId"',
+        't.driver_id AS "driverId"',
+        't.vehicle_id AS "vehicleId"',
+        't.current_status AS "currentStatus"',
+        't.payment_mode AS "paymentMode"',
+        't.requested_at AS "requestedAt"',
+        't.pickup_address AS "pickupAddress"',
+        't.fare_final_currency AS "fareFinalCurrency"',
+        't.fare_total AS "fareTotal"',
+      ])
+      .orderBy('t.requested_at', 'DESC');
+
+    if (filters) this.applyFilters(qb, filters);
+    this.paginate(qb, page, limit);
+
+    try {
+      const [rows, total] = await Promise.all([
+        qb.getRawMany<TripListItemProjection>(),
+        this.countWithFilters(filters),
+      ]);
+      return [rows, total];
+    } catch (err) {
+      handleRepositoryError(
+        this.logger,
+        err,
+        'findListPaginatedProjection',
+        this.entityName,
+      );
+    }
+  }
+
+  /** Update parcial, devuelve entidad actualizada (participa en transacción si pasas manager) */
+  async updatePartial(
+    id: string,
+    patch: DeepPartial<Trip>,
+    manager?: EntityManager,
+  ): Promise<Trip> {
+    const repo = this.scoped(manager);
+    try {
+      await repo.update({ id } as any, patch);
+      const updated = await repo.findOne({
+        where: { id } as any,
+        relations: { passenger: true, driver: true, vehicle: true },
+      });
+      return updated!;
+    } catch (err) {
+      handleRepositoryError(this.logger, err, 'updatePartial', this.entityName);
+    }
+  }
+
+  /** Viaje activo por pasajero (pending/assigning/accepted/arriving/in_progress) */
+  async findActiveByPassenger(passengerId: string): Promise<Trip | null> {
+    const active: TripStatus[] = [
+      TripStatus.PENDING,
+      TripStatus.ASSIGNING,
+      TripStatus.ACCEPTED,
+      TripStatus.ARRIVING,
+      TripStatus.IN_PROGRESS,
+    ];
+    const qb = this.qb('t')
+      .leftJoinAndSelect('t.driver', 'driver')
+      .leftJoinAndSelect('t.vehicle', 'vehicle')
+      .where('t.passenger_id = :pid', { pid: passengerId })
+      .andWhere('t.current_status IN (:...st)', { st: active })
+      .orderBy('t.requested_at', 'DESC')
+      .limit(1);
+
+    return this.getOneSafe(qb, 'findActiveByPassenger');
+  }
+
+  /** (Opcional) lectura con lock para flujos sensibles a concurrencia */
+  async findByIdForUpdate(
+    id: string,
+    manager?: EntityManager,
+  ): Promise<Trip | null> {
+    try {
+      const qb = (manager ? manager.getRepository(Trip) : this).createQueryBuilder('t');
+      return await qb
+        .setLock('pessimistic_write')
+        .where('t.id = :id', { id })
+        .getOne();
+    } catch (err) {
+      handleRepositoryError(
+        this.logger,
+        err,
+        'findByIdForUpdate',
+        this.entityName,
+      );
+    }
+  }
+
+  // ----------------- Helpers privados -----------------
+
+  /** Aplica filtros del FindTripsQueryDto usando SIEMPRE nombres de columna reales */
+  private applyFilters(qb: SelectQueryBuilder<Trip>, f: TripsQueryDto): void {
+    if (f.passengerId)  qb.andWhere('t.passenger_id = :pid', { pid: f.passengerId });
+    if (f.driverId)     qb.andWhere('t.driver_id = :did', { did: f.driverId });
+    if (f.vehicleId)    qb.andWhere('t.vehicle_id = :vid', { vid: f.vehicleId });
+    if (f.status)       qb.andWhere('t.current_status = :st', { st: f.status });
+    if (f.paymentMode)  qb.andWhere('t.payment_mode = :pm', { pm: f.paymentMode });
+
+    if (f.requestedFrom) qb.andWhere('t.requested_at >= :rf', { rf: f.requestedFrom });
+    if (f.requestedTo)   qb.andWhere('t.requested_at <= :rt', { rt: f.requestedTo });
+
+    if (f.completedFrom) qb.andWhere('t.completed_at >= :cf', { cf: f.completedFrom });
+    if (f.completedTo)   qb.andWhere('t.completed_at <= :ct', { ct: f.completedTo });
+  }
+
+  /** Conteo total con los mismos filtros (para proyección) */
+  private async countWithFilters(filters?: TripsQueryDto): Promise<number> {
+    const qb = this.qb('t').select('t.id');
+    if (filters) this.applyFilters(qb, filters);
+    try {
+      return await qb.getCount();
+    } catch (err) {
+      handleRepositoryError(this.logger, err, 'countWithFilters', this.entityName);
+    }
+  }
+
+  /**
+ * Busca viajes cuyo pickup esté dentro de un radio (metros) desde (lat,lng),
+ * devolviendo ENTIDADES + relaciones (passenger, driver, vehicle),
+ * ordenados por cercanía y paginados.
+ *
+ * Requiere índice espacial:
+ *   CREATE INDEX IF NOT EXISTS idx_trips_pickup_point_gist
+ *   ON trips USING GIST (pickup_point);
+ */
+async findNearbyPickupsEntities(
+  params: NearbyParams,
+  manager?: EntityManager,
+): Promise<[Trip[], number]> {
+  const {
+    lat,
+    lng,
+    radiusMeters,
+    statusIn,
+    page = 1,
+    limit = 10,
+  } = params;
+
+  // saneo del radio (evita scans absurdos)
+  const meters = Math.max(1, Math.min(100_000, Math.floor(radiusMeters || 0))); // 1 m .. 100 km
+
+  const repo = this.scoped(manager);
+  const qb = repo
+    .createQueryBuilder('t')
+    .leftJoinAndSelect('t.passenger', 'passenger')
+    .leftJoinAndSelect('t.driver', 'driver')
+    .leftJoinAndSelect('t.vehicle', 'vehicle')
+    // .leftJoinAndSelect('t.order', 'order') // ← descomenta si EXISTE esa relación en tu entidad
+    // filtro geoespacial por radio (GEOGRAPHY usa METROS)
+    .where(
+      `ST_DWithin(
+         t.pickup_point,
+         ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography,
+         :meters
+       )`,
+    )
+    // distancia (metros) para ordenar por cercanía
+    .addSelect(
+      `ST_Distance(
+         t.pickup_point,
+         ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography
+       )`,
+      'distanceMeters',
+    )
+    .setParameters({ lat, lng, meters })
+    .orderBy('distanceMeters', 'ASC');
+
+  // filtro opcional de estados
+  if (statusIn?.length) {
+    qb.andWhere('t.current_status IN (:...st)', { st: statusIn });
+  }
+
+  // paginación estándar de tu BaseRepository
+  this.paginate(qb, page, limit);
+
+  try {
+    // entidades + total con tu wrapper centralizado
+    return await this.getManyAndCountSafe(qb, 'findNearbyPickupsEntities');
+  } catch (err) {
+    handleRepositoryError(this.logger, err, 'findNearbyPickupsEntities', this.entityName);
+    throw err;
+  }
+}
+}


### PR DESCRIPTION
This commit introduces the foundation for the new `Trip` feature, including its entity, repository, and related interfaces.

- **Trip Entity:** Creates the `Trip` entity and its corresponding interfaces.
- **Base Repository:** Implements a new `BaseRepository` to centralize common database functionalities like pagination and error handling. This promotes reusability and clean code.
- **Global Interceptor:** Adds `ApiResponseInterceptor` to standardize API responses with a consistent `success`, `message`, and `data` format.
- **Postgres Helpers:** Creates a helper to handle and translate specific PostgreSQL error codes, improving error handling and clarity.