### PR TITLE
feat(wallet): add enforce negative-balance policy and add block/unblo…

### DIFF
--- a/src/modules/driver_balance/entities/driver_balance.entity.ts
+++ b/src/modules/driver_balance/entities/driver_balance.entity.ts
@@ -78,8 +78,46 @@ export class DriverBalance {
   payoutMethodId?: string | null;
 
   // status para bloquear wallet si es necesario (fraude, reclamo)
+  @Index('idx_driver_balance_status')
   @Column({ name: 'status', type: 'varchar', length: 20, default: 'active' })
   status: 'active' | 'blocked';
+
+  /**
+   * Campos de trazabilidad para bloqueo/desbloqueo
+   * - blocked_at / blocked_reason: cuándo y por qué se bloqueó
+   * - unblocked_at / unblocked_by: cuándo y por quién se desbloqueó (admin ID u null)
+   */
+  @Column({ name: 'blocked_at', type: 'timestamptz', nullable: true })
+  blockedAt?: Date | null;
+
+  @Column({ name: 'blocked_reason', type: 'varchar', length: 250, nullable: true })
+  blockedReason?: string | null;
+
+  @Column({ name: 'unblocked_at', type: 'timestamptz', nullable: true })
+  unblockedAt?: Date | null;
+
+  @Column({ name: 'unblocked_by', type: 'uuid', nullable: true })
+  unblockedBy?: string | null;
+
+  /**
+   * Opcional: límite negativo permitido por conductor.
+   * - Si tu política actual no lo permite, puedes eliminar/ignorar este campo.
+   * - Si lo mantienes, valores <= 0 (ej. -50.00) representan cuánto puede llegar a deber el driver
+   */
+  @Column({
+    name: 'allowed_negative_limit',
+    type: 'numeric',
+    precision: 14,
+    scale: 2,
+    nullable: true,
+    default: 0,
+    transformer: DecimalTransformer,
+  })
+  allowedNegativeLimit?: number | null;
+
+  // Optimistic locking / control de concurrencia a nivel de ORM (útil además del FOR UPDATE)
+  @VersionColumn()
+  version: number;
 
   @Column({ name: 'last_updated', type: 'timestamptz', default: () => 'NOW()' })
   lastUpdated: Date;


### PR DESCRIPTION
Summary:
- Implement platform rule that allows a single operation to put a driver's wallet into negative balance and immediately marks the wallet as blocked.
- Add audit fields to DriverBalance to track block/unblock events.

What changed:
- Repository:
  - add/adjusted methods: lockByDriverId, blockWalletLocked, unblockWalletLocked, updateBalanceLocked, createAndSave (consistent locking and rounding).
- Service:
  - applyCashTripCommission now:
    * rejects debits if wallet.status === 'blocked'
    * applies debit, persists movement and balance, and if the operation causes balance < 0 (and previous >= 0) marks wallet as blocked with blockedAt/blockedReason
  - confirmCashTopup now:
    * applies top-up, persists movement and balance
    * if wallet was blocked and newBalance >= 0, unblocks wallet and sets unblockedAt/unblockedBy
- Idempotency:
  - kept existing idempotency checks for transactions/CCR/movements; repo/service flow verifies existing transaction/movement before creating duplicates.
- Concurrency:
  - all balance-changing operations use FOR UPDATE (pessimistic lock) to serialize per-wallet operations and avoid race conditions.
- Helpers:
  - rounding/lastUpdated usage unified via updateBalanceLocked to ensure consistent state.